### PR TITLE
feat(facebook): integração completa com Graph API, whitelist de obras e release automático

### DIFF
--- a/.envExample
+++ b/.envExample
@@ -1,9 +1,75 @@
+# =============================================================================
+# DISCORD
+# =============================================================================
+
+# Token de autenticação do bot Discord.
+# Obtido em: https://discord.com/developers/applications → Bot → Token
 API_KEY = token_bot_discord
-CANAL_LANCAMENTOS = channel_id
-CANAL_TESTES = channel_id_tests
-CANAL_TAGS = channel_id_tags
 
-API_ID_PAGINA_FACEBOOK = api_facebook
-API_TOKEN_PAGINA = token_facebook_page
+# ID do canal Discord onde as postagens de lançamentos reais serão enviadas.
+# Para obter o ID: ative o Modo Desenvolvedor no Discord, clique com botão direito
+# no canal → Copiar ID
+CANAL_LANCAMENTOS = channel_id_canal_lancamentos
 
-URL_SITE = url_do_site_sem_https//:
+# ID do canal Discord usado para postagens em modo de teste.
+# As mensagens de teste são enviadas aqui em vez do canal de produção.
+CANAL_TESTES = channel_id_canal_testes
+
+# ID do canal Discord onde as postagens com tags/menções de obras são enviadas.
+CANAL_TAGS = channel_id_canal_tags
+
+# =============================================================================
+# MONGODB ATLAS
+# =============================================================================
+
+# URI de conexão com o cluster do MongoDB Atlas.
+# Obtida em: Atlas Console → Database → Connect → Drivers
+# Formato: mongodb+srv://<usuario>:<senha>@<cluster>.mongodb.net/?retryWrites=true&w=majority
+URI_ATLAS = mongodb+srv://usuario:senha@cluster.mongodb.net/?retryWrites=true&w=majority
+
+# =============================================================================
+# FACEBOOK (Produção)
+# =============================================================================
+
+# ID numérico da página do Facebook onde os anúncios serão publicados.
+# Obtido em: Configurações da Página → Informações da Página → ID da Página
+API_ID_PAGINA_FACEBOOK = id_numerico_da_pagina_facebook
+
+# Token de acesso de longa duração da página do Facebook (produção).
+# Gerado via: https://developers.facebook.com/tools/explorer/
+# Permissões necessárias: pages_manage_posts, pages_read_engagement, publish_to_groups
+API_TOKEN_PAGINA = token_de_acesso_da_pagina_facebook
+
+# =============================================================================
+# FACEBOOK (Testes)
+# Usadas apenas quando ENABLE_FB_TEST=true. Permitem testar a integração com o
+# Facebook sem publicar na página de produção.
+# =============================================================================
+
+# ID numérico da página do Facebook de testes.
+API_ID_PAGINA_FACEBOOK_TESTE = id_numerico_da_pagina_de_teste
+
+# Token de acesso de longa duração da página do Facebook de testes.
+API_TOKEN_PAGINA_TESTE = token_de_acesso_da_pagina_de_teste
+
+# Ativa o modo de teste do Facebook.
+# Quando "true", as postagens são feitas na página de teste (acima) em vez da produção.
+# Quando "false" ou ausente, usa as credenciais de produção.
+# Padrão: false
+ENABLE_FB_TEST = false
+
+# =============================================================================
+# GOOGLE GEMINI
+# =============================================================================
+
+# Chave de API do Google Gemini, usada para geração de descrições das obras.
+# Obtida em: https://aistudio.google.com/app/apikey
+GEMINI_API = chave_de_api_do_gemini
+
+# =============================================================================
+# WEB SCRAPER
+# =============================================================================
+
+# URL base do site alvo do scraper, sem protocolo (http:// ou https://).
+# Exemplo: tsundoku.com.br
+URL_SITE = url_do_site_sem_protocolo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Gerar Release Notes e publicar Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (histórico completo para o git-cliff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Gerar CHANGELOG com git-cliff
+        uses: orhun/git-cliff-action@v3
+        id: git_cliff
+        with:
+          config: cliff.toml
+          args: --verbose --latest --strip header
+        env:
+          OUTPUT: CHANGELOG_RELEASE.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Criar GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          body_path: CHANGELOG_RELEASE.md
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-pytest.yaml
+++ b/.github/workflows/test-pytest.yaml
@@ -35,13 +35,24 @@ jobs:
 
       - name: Run Pytest with secrets
         env:
-          API_ID_PAGINA_FACEBOOK: ${{ secrets.API_ID_PAGINA_FACEBOOK }}
+          # Discord
           API_KEY: ${{ secrets.API_KEY }}
-          API_TOKEN_PAGINA: ${{ secrets.API_TOKEN_PAGINA }}
           CANAL_LANCAMENTOS: ${{ secrets.CANAL_LANCAMENTOS }}
-          CANAL_TAGS: ${{ secrets.CANAL_TAGS }}
           CANAL_TESTES: ${{ secrets.CANAL_TESTES }}
+          CANAL_TAGS: ${{ secrets.CANAL_TAGS }}
+          # MongoDB Atlas
           URI_ATLAS: ${{ secrets.URI_ATLAS }}
+          # Facebook — produção
+          API_ID_PAGINA_FACEBOOK: ${{ secrets.API_ID_PAGINA_FACEBOOK }}
+          API_TOKEN_PAGINA: ${{ secrets.API_TOKEN_PAGINA }}
+          # Facebook — testes de integração (desabilitado na CI por padrão)
+          API_ID_PAGINA_FACEBOOK_TESTE: ${{ secrets.API_ID_PAGINA_FACEBOOK_TESTE }}
+          API_TOKEN_PAGINA_TESTE: ${{ secrets.API_TOKEN_PAGINA_TESTE }}
+          ENABLE_FB_TEST: "false"
+          # Google Gemini
+          GEMINI_API: ${{ secrets.GEMINI_API }}
+          # Web scraper
+          URL_SITE: ${{ secrets.URL_SITE }}
         run: |
           export PYTHONPATH=$(pwd)
           LC_ALL=pt_BR.UTF-8 LANG=pt_BR.UTF-8 python -m pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ node_modules/
 ## cache python
 __pycache__/
 *.py[cod]
+*.pyc

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ flowchart TD
         OBRA["Obra"]
         CAPITULO["Capitulo"]
         POST_DC["PostDiscord\nMonta o embed\ndo anúncio"]
-        POST_FB["PostFacebook\n(desativado)"]
+        POST_FB["PostFacebook"]
         MSGS["Mensagens\nLogs e prints"]
         LOGGER["LoggerConfig\nConfiguração de logs"]
     end
@@ -105,7 +105,7 @@ flowchart TD
 | Variável | Descrição |
 |---|---|
 | `API_ID_PAGINA_FACEBOOK` | ID numérico da página do Facebook de produção onde os posts serão publicados |
-| `API_TOKEN_PAGINA` | Page Access Token da página de produção. Deve ter as permissões `pages_manage_posts` e `pages_read_engagement` |
+| `API_TOKEN_PAGINA` | Page Access Token de longa duração da página de produção. Veja [configuracao_facebook.md](docs/configuracao_facebook.md) para instruções de geração |
 | `API_ID_PAGINA_FACEBOOK_TESTE` | ID numérico da página de teste (usada apenas quando `ENABLE_FB_TEST=true`) |
 | `API_TOKEN_PAGINA_TESTE` | Page Access Token da página de teste |
 | `ENABLE_FB_TEST` | `"true"` para habilitar os testes unitários de postagem no Facebook. Por padrão `"false"` para evitar postagens acidentais |
@@ -114,87 +114,7 @@ flowchart TD
 
 ## Configuração do Facebook
 
-### Pré-requisitos
-
-- Conta de desenvolvedor Meta: https://developers.facebook.com
-- App criado no painel de desenvolvedores (tipo: **Business**)
-- Página do Facebook onde os posts serão publicados
-- A conta deve ser **Administrador** da página
-
-### 1. Criar o App no Meta for Developers
-
-1. Acesse https://developers.facebook.com/apps
-2. Clique em **Create App** → selecione o tipo **Business**
-3. Preencha o nome do app e o e-mail de contato
-4. O app começa no modo **Desenvolvimento** — suficiente para testes
-
-### 2. Configurar permissões do App
-
-1. No painel do app, vá em **App Review → Permissions and Features**
-2. Certifique-se de que as seguintes permissões estão presentes:
-   - `pages_manage_posts` ✅
-   - `pages_read_engagement` ✅
-   - `pages_show_list` ✅
-3. **Remova** `publish_actions` se estiver listado — está **deprecated** e bloqueia qualquer postagem com erro 403
-
-### 3. Gerar o Page Access Token
-
-O token necessário é um **Page Access Token**, não um User Token.
-
-1. Acesse https://developers.facebook.com/tools/explorer
-2. Selecione o seu app no dropdown **"App da Meta"**
-3. Em **Permissions**, adicione:
-   - `pages_manage_posts`
-   - `pages_read_engagement`
-   - `pages_show_list`
-4. Clique em **Generate Access Token** e autorize
-5. No campo da query, coloque `/me/accounts` e clique **Enviar**
-6. Na resposta JSON, localize a página desejada dentro de `data[]`:
-   ```json
-   {
-     "data": [
-       {
-         "name": "Nome da Página",
-         "id": "110041288738055",
-         "access_token": "EAACxxx..."
-       }
-     ]
-   }
-   ```
-7. Copie o `access_token` e o `id` da página
-
-> ⚠️ O token gerado pelo Explorer é de **curta duração** (~1h). Para produção, converta para long-lived token via:
-> ```
-> GET https://graph.facebook.com/v25.0/oauth/access_token
->   ?grant_type=fb_exchange_token
->   &client_id={app_id}
->   &client_secret={app_secret}
->   &fb_exchange_token={short_lived_token}
-> ```
-
-### 4. Atualizar o `.env`
-
-```ini
-API_ID_PAGINA_FACEBOOK = "ID_DA_PAGINA"
-API_TOKEN_PAGINA = "PAGE_ACCESS_TOKEN"
-
-# Para testes (pode ser a mesma página ou uma página separada)
-API_ID_PAGINA_FACEBOOK_TESTE = "ID_DA_PAGINA_TESTE"
-API_TOKEN_PAGINA_TESTE = "PAGE_ACCESS_TOKEN_TESTE"
-ENABLE_FB_TEST = "false"
-```
-
-### 5. Testar a integração
-
-```bash
-# Habilitar testes de Facebook no .env:
-ENABLE_FB_TEST = "true"
-
-# Executar apenas os testes de Facebook:
-pytest tests/test_dao_conexao_facebook.py -v
-```
-
-> Ao terminar os testes, retorne `ENABLE_FB_TEST = "false"` para evitar postagens acidentais nas próximas execuções do `pytest`.
+Consulte o guia completo em [docs/configuracao_facebook.md](docs/configuracao_facebook.md).
 
 ---
 
@@ -213,7 +133,7 @@ bot-notification/
 │   ├── dao/
 │   │   ├── atlas_dao.py             # Acesso ao MongoDB Atlas
 │   │   ├── conexao_discord.py       # Envio de mensagens ao Discord
-│   │   ├── conexao_facebook.py      # Integração Facebook (desativada)
+│   │   ├── conexao_facebook.py      # Integração Facebook (Graph API v25.0)
 │   │   ├── gemini_dao.py            # Integração Google Gemini AI
 │   │   └── web_screper_site.py      # Web scraping do site de mangás
 │   ├── endpoint/
@@ -226,7 +146,7 @@ bot-notification/
 │       ├── obra.py                  # Entidade Obra
 │       └── posts/
 │           ├── post_discord.py      # Modelo do embed Discord
-│           └── post_facebook.py     # Modelo do post Facebook (desativado)
+│           └── post_facebook.py     # Modelo do post Facebook
 ├── assets/                          # Volume Docker (persistente)
 │   ├── config/
 │   │   └── test_mode.txt            # "true" para modo de teste

--- a/README.md
+++ b/README.md
@@ -79,14 +79,122 @@ flowchart TD
 
 ### Variáveis de ambiente (`.env`)
 
+#### Discord
+
 | Variável | Descrição |
 |---|---|
-| `URI_ATLAS` | URI de conexão com o MongoDB Atlas |
-| `API_KEY` | Token do bot Discord |
-| `CANAL_LANCAMENTOS` | ID do canal de lançamentos |
-| `CANAL_TAGS` | ID do canal de tags/cargos |
-| `CANAL_TESTES` | ID do canal usado em modo de teste |
-| `GEMINI_API` | Chave da API do Google Gemini |
+| `API_KEY` | Token do bot Discord. Obtido em https://discord.com/developers/applications → Bot → Token |
+| `CANAL_LANCAMENTOS` | ID do canal onde os anúncios de lançamentos são postados em produção |
+| `CANAL_TESTES` | ID do canal usado quando o bot é executado em modo de teste |
+| `CANAL_TAGS` | ID do canal de tags/cargos, usado para menções nos embeds |
+
+#### MongoDB Atlas
+
+| Variável | Descrição |
+|---|---|
+| `URI_ATLAS` | URI de conexão com o cluster MongoDB Atlas. Formato: `mongodb+srv://<user>:<password>@<cluster>.mongodb.net/` |
+
+#### Google Gemini
+
+| Variável | Descrição |
+|---|---|
+| `GEMINI_API` | Chave da API do Google Gemini AI. Obtida em https://aistudio.google.com/app/apikey |
+
+#### Facebook
+
+| Variável | Descrição |
+|---|---|
+| `API_ID_PAGINA_FACEBOOK` | ID numérico da página do Facebook de produção onde os posts serão publicados |
+| `API_TOKEN_PAGINA` | Page Access Token da página de produção. Deve ter as permissões `pages_manage_posts` e `pages_read_engagement` |
+| `API_ID_PAGINA_FACEBOOK_TESTE` | ID numérico da página de teste (usada apenas quando `ENABLE_FB_TEST=true`) |
+| `API_TOKEN_PAGINA_TESTE` | Page Access Token da página de teste |
+| `ENABLE_FB_TEST` | `"true"` para habilitar os testes unitários de postagem no Facebook. Por padrão `"false"` para evitar postagens acidentais |
+
+---
+
+## Configuração do Facebook
+
+### Pré-requisitos
+
+- Conta de desenvolvedor Meta: https://developers.facebook.com
+- App criado no painel de desenvolvedores (tipo: **Business**)
+- Página do Facebook onde os posts serão publicados
+- A conta deve ser **Administrador** da página
+
+### 1. Criar o App no Meta for Developers
+
+1. Acesse https://developers.facebook.com/apps
+2. Clique em **Create App** → selecione o tipo **Business**
+3. Preencha o nome do app e o e-mail de contato
+4. O app começa no modo **Desenvolvimento** — suficiente para testes
+
+### 2. Configurar permissões do App
+
+1. No painel do app, vá em **App Review → Permissions and Features**
+2. Certifique-se de que as seguintes permissões estão presentes:
+   - `pages_manage_posts` ✅
+   - `pages_read_engagement` ✅
+   - `pages_show_list` ✅
+3. **Remova** `publish_actions` se estiver listado — está **deprecated** e bloqueia qualquer postagem com erro 403
+
+### 3. Gerar o Page Access Token
+
+O token necessário é um **Page Access Token**, não um User Token.
+
+1. Acesse https://developers.facebook.com/tools/explorer
+2. Selecione o seu app no dropdown **"App da Meta"**
+3. Em **Permissions**, adicione:
+   - `pages_manage_posts`
+   - `pages_read_engagement`
+   - `pages_show_list`
+4. Clique em **Generate Access Token** e autorize
+5. No campo da query, coloque `/me/accounts` e clique **Enviar**
+6. Na resposta JSON, localize a página desejada dentro de `data[]`:
+   ```json
+   {
+     "data": [
+       {
+         "name": "Nome da Página",
+         "id": "110041288738055",
+         "access_token": "EAACxxx..."
+       }
+     ]
+   }
+   ```
+7. Copie o `access_token` e o `id` da página
+
+> ⚠️ O token gerado pelo Explorer é de **curta duração** (~1h). Para produção, converta para long-lived token via:
+> ```
+> GET https://graph.facebook.com/v25.0/oauth/access_token
+>   ?grant_type=fb_exchange_token
+>   &client_id={app_id}
+>   &client_secret={app_secret}
+>   &fb_exchange_token={short_lived_token}
+> ```
+
+### 4. Atualizar o `.env`
+
+```ini
+API_ID_PAGINA_FACEBOOK = "ID_DA_PAGINA"
+API_TOKEN_PAGINA = "PAGE_ACCESS_TOKEN"
+
+# Para testes (pode ser a mesma página ou uma página separada)
+API_ID_PAGINA_FACEBOOK_TESTE = "ID_DA_PAGINA_TESTE"
+API_TOKEN_PAGINA_TESTE = "PAGE_ACCESS_TOKEN_TESTE"
+ENABLE_FB_TEST = "false"
+```
+
+### 5. Testar a integração
+
+```bash
+# Habilitar testes de Facebook no .env:
+ENABLE_FB_TEST = "true"
+
+# Executar apenas os testes de Facebook:
+pytest tests/test_dao_conexao_facebook.py -v
+```
+
+> Ao terminar os testes, retorne `ENABLE_FB_TEST = "false"` para evitar postagens acidentais nas próximas execuções do `pytest`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,44 +1,184 @@
 # Bot de notificações no Discord
-**Branch: developer**
 
-## Instruções Para Dev
+Bot que monitora lançamentos de capítulos em um site de mangás/webtoons e realiza postagens automáticas de anúncio em canais do Discord.
+
+---
+
+## Arquitetura do Projeto
+
+```mermaid
+flowchart TD
+    MAIN["Main.py\n(Ponto de entrada)"]
+
+    subgraph classes_io ["classes_io"]
+        GESTOR["GestorTXT\nLê/grava data anterior\ne modo de teste (TXT)"]
+        DOWNLOAD["DownloadImagens\nBaixa imagens das obras\nregistradas no Atlas"]
+    end
+
+    subgraph controller ["controller"]
+        CTRL_POST["ControllerPostagem\nOrquestra o fluxo\nde postagem"]
+        CTRL_OBRA["ControllerObras\nFiltra e valida\nlistas de obras"]
+    end
+
+    subgraph dao ["dao"]
+        ATLAS["AtlasDAO\nMongoDB Atlas\n(obras registradas,\nanunciadas, etc.)"]
+        SCRAPER["WebScreperSite\nWeb scraping dos\ncapítulos diários do site"]
+        DISCORD["ConexaoDiscord\nEnvia embeds para\ncanais do Discord"]
+        GEMINI["GeminiDAO\nIntegração com\nGoogle Gemini AI"]
+    end
+
+    subgraph model ["model"]
+        OBRA["Obra"]
+        CAPITULO["Capitulo"]
+        POST_DC["PostDiscord\nMonta o embed\ndo anúncio"]
+        POST_FB["PostFacebook\n(desativado)"]
+        MSGS["Mensagens\nLogs e prints"]
+        LOGGER["LoggerConfig\nConfiguração de logs"]
+    end
+
+    subgraph assets ["assets (volume)"]
+        TXT_DATA["registro_horario/\ndata_anterior.txt"]
+        TXT_MODE["config/\ntest_mode.txt"]
+        IMGS["imagens/\n(cache local de imagens)"]
+    end
+
+    MAIN --> GESTOR
+    MAIN --> DOWNLOAD
+    MAIN --> CTRL_POST
+    MAIN --> LOGGER
+
+    GESTOR --> TXT_DATA
+    GESTOR --> TXT_MODE
+
+    DOWNLOAD --> ATLAS
+    DOWNLOAD --> IMGS
+
+    CTRL_POST --> ATLAS
+    CTRL_POST --> SCRAPER
+    CTRL_POST --> CTRL_OBRA
+    CTRL_POST --> POST_DC
+    CTRL_POST --> DISCORD
+
+    SCRAPER --> OBRA
+    SCRAPER --> CAPITULO
+
+    POST_DC --> OBRA
+    POST_DC --> CAPITULO
+
+    CTRL_OBRA --> OBRA
+```
+
+### Fluxo principal
+
+1. **GestorTXT** lê a data da última execução e o modo de teste.
+2. **DownloadImagens** sincroniza o cache local de imagens com os dados do MongoDB Atlas.
+3. **WebScreperSite** faz scraping do site e retorna a lista de obras com capítulos lançados no dia.
+4. **ControllerObras** filtra obras não registradas no Atlas e remove capítulos já anunciados.
+5. **ControllerPostagem** itera sobre as obras restantes, monta um `PostDiscord` e envia o embed via **ConexaoDiscord**.
+6. O registro de obras anunciadas é persistido no MongoDB Atlas para evitar duplicatas.
+
+### Variáveis de ambiente (`.env`)
+
+| Variável | Descrição |
+|---|---|
+| `URI_ATLAS` | URI de conexão com o MongoDB Atlas |
+| `API_KEY` | Token do bot Discord |
+| `CANAL_LANCAMENTOS` | ID do canal de lançamentos |
+| `CANAL_TAGS` | ID do canal de tags/cargos |
+| `CANAL_TESTES` | ID do canal usado em modo de teste |
+| `GEMINI_API` | Chave da API do Google Gemini |
+
+---
+
+## Estrutura de diretórios
+
+```
+bot-notification/
+├── src/
+│   ├── Main.py                      # Ponto de entrada
+│   ├── classes_io/
+│   │   ├── download_imagens.py      # Download de imagens das obras
+│   │   └── gestor_txt.py            # Leitura/escrita de arquivos TXT
+│   ├── controller/
+│   │   ├── controller_obras.py      # Filtragem e validação de obras
+│   │   └── controller_postagem.py   # Orquestração do fluxo de postagem
+│   ├── dao/
+│   │   ├── atlas_dao.py             # Acesso ao MongoDB Atlas
+│   │   ├── conexao_discord.py       # Envio de mensagens ao Discord
+│   │   ├── conexao_facebook.py      # Integração Facebook (desativada)
+│   │   ├── gemini_dao.py            # Integração Google Gemini AI
+│   │   └── web_screper_site.py      # Web scraping do site de mangás
+│   ├── endpoint/
+│   │   ├── bot_endpoint.py
+│   │   └── pagination.py
+│   └── model/
+│       ├── capitulo.py              # Entidade Capítulo
+│       ├── logger_config.py         # Configuração de loggers
+│       ├── mensagens.py             # Mensagens de log/console
+│       ├── obra.py                  # Entidade Obra
+│       └── posts/
+│           ├── post_discord.py      # Modelo do embed Discord
+│           └── post_facebook.py     # Modelo do post Facebook (desativado)
+├── assets/                          # Volume Docker (persistente)
+│   ├── config/
+│   │   └── test_mode.txt            # "true" para modo de teste
+│   ├── imagens/                     # Cache local de capas das obras
+│   └── registro_horario/
+│       └── data_anterior.txt        # Data da última execução
+├── tests/                           # Testes unitários (pytest)
+├── Dockerfile
+├── Dockerfile-dev
+└── requirements.txt
+```
+
+---
+
+## Instruções para desenvolvimento
+
 A versão do Python utilizada é: `python:3.10`
 
-Para criar o ambiente, utilize: 
-```
+Para criar o ambiente, utilize:
+```bash
 python3 -m venv venv
 source venv/bin/activate
 ```
 
 Para instalar as dependências do projeto:
-```
+```bash
 pip install -r requirements.txt
 ```
 
 Para executar os testes:
-```
+```bash
 pytest
 ```
 
-## Para buildar a imagem com docker
-A imagem utiliza volume, então é necessário criar um:
-```
-docker volume create <nome-do-volume> 
+---
+
+## Docker
+
+A imagem utiliza volume para persistir os dados em `assets/`. Crie o volume antes de rodar:
+
+```bash
+docker volume create <nome-do-volume>
 ```
 
-Após isso, para criar a imagem:
-```
+Construir a imagem:
+```bash
 docker build -t bot-notif:<versao-do-bot> .
 ```
 
-E por fim, para executar o container:
-```
+Executar o container:
+```bash
 docker run -d -v <nome-do-volume>:/home/project/assets bot-notif:<versao-do-bot>
 ```
 
-Caso queira acompanhar a saída do bot, pode usar:
-```
+Acompanhar a saída do bot:
+```bash
 docker attach <id-do-container>
 ```
 
-Pode encontrar o ID do container a partir do comando: `docker ps`
+Encontrar o ID do container:
+```bash
+docker ps
+```

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,49 @@
+[changelog]
+header = """
+# Changelog\n
+Todas as mudanças relevantes deste projeto estão documentadas aqui.\n
+"""
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] — {{ timestamp | date(format="%d/%m/%Y") }}
+{% else %}\
+## [Não versionado]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group }}
+{% for commit in commits %}
+- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | upper_first }}\
+{% if commit.breaking %} ⚠️ BREAKING CHANGE{% endif %}\
+
+{% endfor %}
+{% endfor %}\n
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+
+# Ordenação dos commits dentro de cada grupo
+commit_parsers = [
+  { message = "^feat",     group = "🚀 Novidades" },
+  { message = "^fix",      group = "🐛 Correções" },
+  { message = "^refactor", group = "♻️  Refatorações" },
+  { message = "^perf",     group = "⚡ Performance" },
+  { message = "^test",     group = "🧪 Testes" },
+  { message = "^docs?",    group = "📝 Documentação" },
+  { message = "^chore",    group = "🔧 Manutenção" },
+  { message = "^ci",       group = "⚙️  CI/CD" },
+  { message = "^build",    group = "📦 Build" },
+  # ignora commits de merge e bump de versão
+  { message = "^Merge",    skip = true },
+  { message = "^bump",     skip = true },
+]
+
+protect_breaking_commits = false
+filter_commits = true
+tag_pattern = "v[0-9].*"
+topo_order = false
+sort_commits = "newest"

--- a/docs/configuracao_facebook.md
+++ b/docs/configuracao_facebook.md
@@ -1,0 +1,165 @@
+# Configuração da Integração com o Facebook
+
+Este guia cobre o processo completo para criar um app Meta, configurar as permissões necessárias e gerar o Page Access Token para publicações automáticas na página do Facebook.
+
+---
+
+## Pré-requisitos
+
+- Conta no [Meta for Developers](https://developers.facebook.com) (pode usar conta Facebook pessoal)
+- Página do Facebook que você **administra** (onde os posts serão publicados)
+
+---
+
+## 1. Criar o App no Meta for Developers
+
+1. Acesse https://developers.facebook.com/apps
+2. Clique em **Criar App**
+3. Em **Qual é o caso de uso do seu app?**, selecione **"Outros"** e clique em Próximo
+4. Selecione o tipo **Business** e clique em Próximo
+5. Preencha o **Nome de exibição do app** e o e-mail de contato
+6. Clique em **Criar App**
+
+---
+
+## 2. Adicionar o caso de uso "Gerenciar tudo na sua Página"
+
+1. Após criar o app, você será redirecionado para o painel **Adicionar produtos ao seu app**
+2. Localize o caso de uso **"Gerenciar tudo na sua Página"** (_Manage everything on your Page_)
+3. Clique em **Configurar** nesse caso de uso
+
+---
+
+## 3. Configurar as permissões
+
+1. No menu lateral, vá em **Casos de uso** (ou _Use Cases_)
+2. Localize **"Gerenciar tudo na sua Página"** e clique em **Personalizar**
+3. Na aba **Permissões**, clique em **Adicionar** para cada uma das permissões abaixo:
+
+   | Permissão | Finalidade |
+   |---|---|
+   | `pages_show_list` | Listar as páginas gerenciadas pela conta |
+   | `pages_read_engagement` | Ler métricas e engajamento da página |
+   | `pages_read_user_content` | Ler conteúdo publicado por usuários na página |
+   | `pages_manage_posts` | Criar, editar e excluir posts na página |
+   | `pages_manage_engagement` | Gerenciar comentários e interações da página |
+
+4. Após adicionar todas as permissões, confirme que as cinco aparecem listadas na seção **Permissões** da personalização do caso de uso
+
+> ℹ️ Não é necessário submeter o app para revisão da Meta enquanto você for **Administrador** da página e estiver testando com contas de desenvolvedor listadas no app.
+
+---
+
+## 4. Gerar o Page Access Token via `/me/accounts`
+
+O token necessário é um **Page Access Token** (não User Token). A forma mais simples de obtê-lo é pela rota `/me/accounts`:
+
+1. Acesse o [Graph API Explorer](https://developers.facebook.com/tools/explorer/?method=GET&path=me%2Faccounts&version=v25.0)
+2. No dropdown **"App da Meta"**, selecione o app que você criou
+3. Certifique-se de que **"User Token"** está selecionado em **"User or Page"**
+4. Certifique-se de que as seguintes permissões estão marcadas no campo **Permissões**:
+   - `pages_show_list`
+   - `pages_read_engagement`
+   - `pages_read_user_content`
+   - `pages_manage_posts`
+   - `pages_manage_engagement`
+5. Clique em **Gerar token de acesso** e autorize no popup
+6. O caminho `/me/accounts` já estará preenchido — clique em **Enviar**
+
+### Obtendo o ID e o token da página
+
+O `access_token` e o `id` corretos são os da **página**, não do usuário. Para obtê-los:
+
+1. No [Graph API Explorer](https://developers.facebook.com/tools/explorer/?method=GET&path=me%2Faccounts&version=v25.0), certifique-se de que o **User Access Token** está selecionado (não Page Token)
+2. O caminho `/me/accounts` já estará preenchido — clique em **Enviar**
+3. A resposta listará todas as páginas que você administra:
+   ```json
+   {
+     "data": [
+       {
+         "access_token": "EAACxxx...",
+         "category": "Entretenimento",
+         "name": "Nome da Página",
+         "id": "110041288738055",
+         "tasks": ["ANALYZE", "ADVERTISE", "MODERATE", "CREATE_CONTENT"]
+       }
+     ]
+   }
+   ```
+4. Copie o `access_token` e o `id` do objeto correspondente à sua página
+   - `id` → valor de `API_ID_PAGINA_FACEBOOK`
+   - `access_token` → valor de `API_TOKEN_PAGINA`
+
+> ⚠️ **Importante:** use o `access_token` que vem dentro de `data[]` (token da página), não o User Access Token exibido no topo do Explorer. Tokens de usuário não têm permissão para publicar na página.
+
+---
+
+## 5. Converter para token de longa duração (produção)
+
+O token gerado pelo Explorer tem validade de **~1 hora**. Para uso em produção, converta para um token de longa duração (~60 dias):
+
+```
+GET https://graph.facebook.com/v25.0/oauth/access_token
+  ?grant_type=fb_exchange_token
+  &client_id={APP_ID}
+  &client_secret={APP_SECRET}
+  &fb_exchange_token={TOKEN_CURTA_DURACAO}
+```
+
+- `APP_ID` e `APP_SECRET`: encontrados em **Painel do App → Configurações → Básico**
+- Substitua `{TOKEN_CURTA_DURACAO}` pelo token gerado no Explorer
+
+O token retornado tem validade de ~60 dias. Para renovação automática, consulte a [documentação de tokens da Meta](https://developers.facebook.com/docs/facebook-login/guides/access-tokens/get-long-lived/).
+
+---
+
+## 6. Atualizar o `.env`
+
+Adicione as variáveis ao arquivo `.env` na raiz do projeto:
+
+```ini
+# Facebook — Produção
+API_ID_PAGINA_FACEBOOK = "110041288738055"
+API_TOKEN_PAGINA = "EAACxxx..."
+
+# Facebook — Testes (opcional, necessário apenas para rodar testes de integração)
+API_ID_PAGINA_FACEBOOK_TESTE = "ID_DA_PAGINA_DE_TESTE"
+API_TOKEN_PAGINA_TESTE = "EAACxxx..."
+ENABLE_FB_TEST = "false"
+```
+
+> ⚠️ Nunca commite o `.env` com tokens reais. O arquivo `.env` já está no `.gitignore`.
+
+---
+
+## 7. Testar a integração
+
+Para rodar os testes de integração com Facebook (faz postagens reais na página de teste):
+
+```bash
+# No .env, habilite o modo de teste:
+ENABLE_FB_TEST = "true"
+
+# Execute apenas os testes de Facebook:
+venv/bin/python -m pytest tests/test_dao_conexao_facebook.py -v
+```
+
+> Após os testes, retorne `ENABLE_FB_TEST = "false"` para evitar postagens acidentais em execuções futuras do pytest.
+
+---
+
+## Whitelist de obras permitidas no Facebook
+
+Nem todas as obras são postadas no Facebook — apenas as que estiverem na coleção `obrasPermitidasFB` do MongoDB Atlas.
+
+Para adicionar uma obra via bot Discord, use o comando:
+```
+/adicionar_obra_permitida_fb
+```
+
+Para listar as obras atualmente permitidas:
+```
+/listar_obras_permitidas_fb
+```
+
+O nome deve ser **exatamente igual** ao `titulo_obra` registrado no Atlas.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ certifi==2023.5.7
 charset-normalizer==3.1.0
 discord.py==2.3.1
 dnspython==1.16.0
-facebook-sdk==3.1.0
 frozenlist==1.3.3
 google-ai-generativelanguage==0.6.2
 google-api-core==2.19.0

--- a/src/controller/controller_obras.py
+++ b/src/controller/controller_obras.py
@@ -30,22 +30,33 @@ class ControllerObras:
         return obras_registradas
 
 
-    """
-    Remove obras que não podem ser postadas.
-    Args:
-        lista_de_obras_para_postar (list): Lista de obras para postar.
-        lista_de_obras_nao_permitidas (list): Lista de obras não permitidas.
-    Returns:
-        list: Lista de obras filtradas, sem as obras não permitidas.
-    """
-    def remover_obras_que_nao_pode_postar(lista_de_obras_para_postar, lista_de_obras_nao_permitidas):
-        titulos_obras_nao_permitidas = [obra['titulo_obra'] for obra in lista_de_obras_nao_permitidas]
+    def filtrar_obras_permitidas_fb(
+        lista_de_obras_para_postar: list,
+        lista_de_obras_permitidas: list
+    ) -> list:
+        """
+        Retorna apenas as obras que possuem permissão explícita de
+        postagem no Facebook (whitelist).
 
-        obras_filtradas = [
+        Obras que não estiverem na lista de permitidas são removidas,
+        independente de qualquer outro critério.
+
+        Args:
+            lista_de_obras_para_postar (list): obras candidatas à postagem.
+            lista_de_obras_permitidas (list): documentos com 'titulo_obra'
+                das obras autorizadas.
+
+        Returns:
+            list: obras presentes em lista_de_obras_permitidas.
+        """
+        titulos_permitidos = {
+            obra['titulo_obra'] for obra in lista_de_obras_permitidas
+        }
+
+        return [
             obra for obra in lista_de_obras_para_postar
-            if obra.titulo_obra not in titulos_obras_nao_permitidas
+            if obra.titulo_obra in titulos_permitidos
         ]
-        return obras_filtradas
 
 
     """

--- a/src/controller/controller_postagem.py
+++ b/src/controller/controller_postagem.py
@@ -66,11 +66,11 @@ class ControllerPostagem:
 
                 time.sleep(10)
 
-            # Postagem do FB
-            lista_de_obras_nao_permitidas = atlas_dao.listar_obras_nao_permitidas_fb()
+            # Postagem do FB — apenas obras com permissão explícita (whitelist)
+            lista_de_obras_permitidas_fb = atlas_dao.listar_obras_permitidas_fb()
 
-            lista_de_obras_facebook = ControllerObras.remover_obras_que_nao_pode_postar(
-                lista_de_obras_atualizada, lista_de_obras_nao_permitidas
+            lista_de_obras_facebook = ControllerObras.filtrar_obras_permitidas_fb(
+                lista_de_obras_atualizada, lista_de_obras_permitidas_fb
             )
 
             for obra in lista_de_obras_facebook:

--- a/src/controller/controller_postagem.py
+++ b/src/controller/controller_postagem.py
@@ -3,9 +3,10 @@ import time
 from src.dao.web_screper_site import WebScreperSite
 from src.dao.conexao_discord import ConexaoDiscord
 from src.dao.atlas_dao import AtlasDAO
-#from src.dao.conexao_facebook import ConexaoFacebook
+from src.dao.conexao_facebook import ConexaoFacebook
 from src.controller.controller_obras import ControllerObras
 from src.model.posts.post_discord import PostDiscord
+from src.model.posts.post_facebook import PostFacebook
 from src.classes_io.gestor_txt import GestorTXT
 
 from model.mensagens import Mensagens
@@ -65,21 +66,22 @@ class ControllerPostagem:
 
                 time.sleep(10)
 
-            """ Postagem do FB
+            # Postagem do FB
             lista_de_obras_nao_permitidas = atlas_dao.listar_obras_nao_permitidas_fb()
 
-            lista_de_obras_facebook = ControllerObras.remover_obras_que_nao_pode_postar(lista_de_obras_atualizada,lista_de_obras_nao_permitidas)
+            lista_de_obras_facebook = ControllerObras.remover_obras_que_nao_pode_postar(
+                lista_de_obras_atualizada, lista_de_obras_nao_permitidas
+            )
 
             for obra in lista_de_obras_facebook:
                 try:
                     Mensagens.post_facebook(obra.titulo_obra)
                     post_obra_Facebook = PostFacebook(obra, atlas_dao.receber_obras())
-                    #Conexao_Facebook.postar_anuncio_facebook(post_obra_Facebook)
-                
+                    ConexaoFacebook.postar_anuncio_facebook(post_obra_Facebook)
+
                 except Exception as e:
                     Mensagens.erro_no_codigo(e)
                     Mensagens.nao_foi_possivel_postar_facebook()
                     Mensagens.mensagem_nao_foi_possivel_postar_obra(obra.titulo_obra)
 
                 time.sleep(10)
-            """

--- a/src/dao/atlas_dao.py
+++ b/src/dao/atlas_dao.py
@@ -225,15 +225,22 @@ class AtlasDAO:
             Mensagens.erro_no_banco_de_dados(f"Erro ao remover registros do MongoDB: {e}")
 
 
-    def inserir_obra_nao_permitida_fb(self, dicionario_obra):
-        db = self.client.DadosPostagem
-        colecao = db.obrasNaoPermitidasFB
+    def inserir_obra_permitida_fb(self, dicionario_obra: dict) -> None:
+        """
+        Insere uma obra na whitelist de postagem do Facebook.
 
-        # Inserir os dados na coleção
+        Parameters:
+            dicionario_obra (dict): documento com a chave 'titulo_obra'.
+        """
+        db = self.client.DadosPostagem
+        colecao = db.obrasPermitidasFB
+
         try:
             colecao.insert_one(dicionario_obra)
         except Exception as e:
-            Mensagens.erro_no_banco_de_dados(f'Erro ao inserir obra não permitida: {e}')
+            Mensagens.erro_no_banco_de_dados(
+                f'Erro ao inserir obra permitida no FB: {e}'
+            )
 
         
     def receber_obras(self):
@@ -252,21 +259,27 @@ class AtlasDAO:
             return []
 
 
-    def listar_obras_nao_permitidas_fb(self):
+    def listar_obras_permitidas_fb(self):
+        """
+        Retorna a lista de obras com permissão explícita de postagem
+        no Facebook, lida da coleção 'obrasPermitidasFB'.
+
+        Returns:
+            list: lista de documentos com a chave 'titulo_obra'.
+        """
         try:
             db = self.client.DadosPostagem
-            colecao = db.obrasNaoPermitidasFB
+            colecao = db.obrasPermitidasFB
 
             projection = {'_id': 0}
 
             todos_documentos = colecao.find({}, projection=projection).sort('titulo_obra', 1)
-            
-            # Convertendo o cursor em uma lista
-            lista_documentos = list(todos_documentos)
 
-            return lista_documentos
+            return list(todos_documentos)
         except Exception as e:
-            Mensagens.erro_no_banco_de_dados(f"Erro ao listar obras não permitidas do MongoDB: {e}")
+            Mensagens.erro_no_banco_de_dados(
+                f"Erro ao listar obras permitidas do MongoDB: {e}"
+            )
             return []
 
 

--- a/src/dao/conexao_facebook.py
+++ b/src/dao/conexao_facebook.py
@@ -1,27 +1,95 @@
+import logging
 import os
+import requests
 from dotenv import load_dotenv
-import facebook
+
 
 class ConexaoFacebook:
 
     def postar_anuncio_facebook(post_obra):
-        def receber_caminho_imagem(titulo_obra):
-            diretorio_imagens = "imagens"
-            caminho_imagem = os.path.join(diretorio_imagens, f"{titulo_obra}.png")
-        
-            return caminho_imagem
+        """
+        Publica uma foto com legenda na página do Facebook via Graph API v25.0.
 
-        load_dotenv()
-        token_de_acesso_fb = os.getenv('API_TOKEN_PAGINA')
-        id_pagina_fb = os.getenv("API_ID_PAGINA_FACEBOOK")
+        Parameters:
+            post_obra: objeto com titulo_obra, imagem_obra e método
+            retornar_mensagem_post().
 
-        graph = facebook.GraphAPI(access_token=token_de_acesso_fb, version="3.0")
+        Raises:
+            requests.HTTPError: se alguma chamada à Graph API retornar erro.
+        """
+        logger_infos = logging.getLogger("logger_infos")
+        logger_erros = logging.getLogger("logger_erros")
 
-        # Faz a postagem
-        # graph.put_object(parent_object=id_pagina_fb, connection_name='feed', message=post_obra.retornar_mensagem_post())
+        load_dotenv(override=True)
 
-        caminho_imagem = receber_caminho_imagem(post_obra.titulo_obra)
-        with open(caminho_imagem, 'rb') as imagem:
-            graph.put_photo(image=imagem, message=post_obra.retornar_mensagem_post())
+        # Em modo de teste, usa credenciais de teste se ENABLE_FB_TEST=true
+        is_test_mode = (
+            os.getenv("ENABLE_FB_TEST", "false").lower() == "true"
+        )
 
-        return
+        if is_test_mode:
+            token_de_acesso_fb = os.getenv("API_TOKEN_PAGINA_TESTE")
+            id_pagina_fb = os.getenv("API_ID_PAGINA_FACEBOOK_TESTE")
+            if not token_de_acesso_fb or not id_pagina_fb:
+                logger_infos.info(
+                    "[MODO TESTE] Credenciais de teste ausentes. "
+                    "Postagem ignorada."
+                )
+                return
+            logger_infos.info(
+                "[MODO TESTE] Usando credenciais de teste do Facebook"
+            )
+        else:
+            token_de_acesso_fb = os.getenv("API_TOKEN_PAGINA")
+            id_pagina_fb = os.getenv("API_ID_PAGINA_FACEBOOK")
+
+        logger_infos.info(f"Postando no Facebook: {post_obra.titulo_obra}")
+
+        # Passo 1: envia a URL da imagem como foto não publicada → obtém photo_id.
+        # Usar URL em vez de upload binário evita criar entradas duplicadas
+        # na galeria da página a cada nova postagem da mesma obra.
+        url_photos = (
+            f"https://graph.facebook.com/v25.0/{id_pagina_fb}/photos"
+        )
+
+        response_upload = requests.post(
+            url_photos,
+            params={"access_token": token_de_acesso_fb},
+            data={
+                "url": post_obra.imagem_obra,
+                "published": "false",
+            },
+        )
+
+        if not response_upload.ok:
+            logger_erros.error(
+                f"Erro no upload da imagem: "
+                f"{response_upload.status_code} — {response_upload.text}"
+            )
+        response_upload.raise_for_status()
+
+        photo_id = response_upload.json().get("id")
+        logger_infos.info(f"Imagem enviada. photo_id: {photo_id}")
+
+        # Passo 2: publica no feed com a imagem anexada via photo_id
+        url_feed = f"https://graph.facebook.com/v25.0/{id_pagina_fb}/feed"
+
+        response_post = requests.post(
+            url_feed,
+            params={"access_token": token_de_acesso_fb},
+            json={
+                "message": post_obra.retornar_mensagem_post(),
+                "attached_media": [{"media_fbid": photo_id}],
+            },
+        )
+
+        if not response_post.ok:
+            logger_erros.error(
+                f"Erro ao publicar post: "
+                f"{response_post.status_code} — {response_post.text}"
+            )
+        response_post.raise_for_status()
+
+        logger_infos.info(
+            f"Postagem no Facebook concluída: {post_obra.titulo_obra}"
+        )

--- a/src/dao/web_screper_site.py
+++ b/src/dao/web_screper_site.py
@@ -19,8 +19,16 @@ class WebScreperSite:
         logger_infos = logging.getLogger('logger_infos')
         logger_infos.info(" Iniciando Web Screper ")
 
-        # Definir o locale como "pt_BR.UTF-8"
-        locale.setlocale(locale.LC_ALL, 'pt_BR.UTF-8')
+        # Definir o locale como "pt_BR.UTF-8".
+        # Em ambientes sem o locale instalado (ex: WSL sem pt_BR gerado)
+        # a configuração é ignorada com um aviso — o Docker tem o locale.
+        try:
+            locale.setlocale(locale.LC_ALL, 'pt_BR.UTF-8')
+        except locale.Error:
+            logger_infos.warning(
+                "Locale pt_BR.UTF-8 não disponível neste ambiente. "
+                "Datas podem não ser formatadas em português."
+            )
 
 
     def recebe_capitulos_diarios(self):

--- a/src/endpoint/bot_endpoint.py
+++ b/src/endpoint/bot_endpoint.py
@@ -127,16 +127,16 @@ async def atualizar_mensagem_obra(interaction: discord.Interaction, titulo: str,
 @app_commands.describe(
     titulo='Titulo que esta no site'
 )
-async def adicionar_obra_nao_permitida_fb(interaction: discord.Interaction, titulo: str):
-    """Obras nessa lista não são postadas no Facebook, por questões de direitos autorais."""
+async def adicionar_obra_permitida_fb(interaction: discord.Interaction, titulo: str):
+    """Obras nessa lista têm permissão explícita para serem postadas no Facebook."""
     try:
         dicionario_obra = {
-            "titulo_obra" : titulo
+            "titulo_obra": titulo
         }
 
-        atlas_dao.inserir_obra_nao_permitida_fb(dicionario_obra)
+        atlas_dao.inserir_obra_permitida_fb(dicionario_obra)
 
-        await interaction.response.send_message(f'{titulo} adicionada com sucesso!')
+        await interaction.response.send_message(f'{titulo} adicionada à whitelist do FB com sucesso!')
     except Exception as e:
         await interaction.response.send_message(f'Erro ao adicionar {titulo}: {e}')
 
@@ -183,16 +183,15 @@ async def listar_obras(interaction: discord.Interaction):
 
 #Comando para listar obras que estão no banco
 @client.tree.command()
-async def listar_obras_nao_permitidas_fb(interaction: discord.Interaction):
-    """Listar obras não permitidas para postagem no FB."""
+async def listar_obras_permitidas_fb(interaction: discord.Interaction):
+    """Listar obras com permissão para postagem no FB (whitelist)."""
 
-    cursor_obras = atlas_dao.listar_obras_nao_permitidas_fb()
-    colecao_obras = list(cursor_obras)  # Convertendo o cursor para uma lista de obras
+    colecao_obras = atlas_dao.listar_obras_permitidas_fb()
 
     max_docs_por_pagina = 10
 
     async def get_page(page: int):
-        emb = discord.Embed(title="Obras Não Permitidas FB", description="Obras que estão salvas no banco de dados.")
+        emb = discord.Embed(title="Obras Permitidas no FB", description="Obras com permissão explícita de postagem no Facebook.")
         offset = (page - 1) * max_docs_por_pagina
 
         parte_documentos = colecao_obras[offset:offset + max_docs_por_pagina]
@@ -202,7 +201,7 @@ async def listar_obras_nao_permitidas_fb(interaction: discord.Interaction):
 
         total_pages = Pagination.compute_total_pages(len(colecao_obras), max_docs_por_pagina)
         emb.set_footer(text=f"Página {page} de {total_pages}")
-        
+
         return emb, total_pages
 
     await Pagination(interaction, get_page).navegate()
@@ -272,7 +271,7 @@ async def informacoes_postagem(interaction: discord.Interaction):
     embed.add_field(name="Horários de verificação", value="12h, 16h, 18h, 20h e 22h", inline=False)
     embed.add_field(name="Adicionar obras novas", value="Use /adicionar_obra(Também atualiza os já adicionados se o título for o mesmo), /listar_obras e /remover_obra.", inline=False)
     embed.add_field(name="Gerenciar Postagem", value="Use /forcar_postagem e /excluir_registros.", inline=False)
-    embed.add_field(name="Gerenciar obras não permitidas no FB", value="Use /adicionar_obra_nao_permitida_fb e /listar_obra_nao_permitida_fb .", inline=False)
+    embed.add_field(name="Gerenciar whitelist do FB", value="Use /adicionar_obra_permitida_fb e /listar_obras_permitidas_fb .", inline=False)
     embed.add_field(name="Comandos utilitários", value="/ping, /joined e /informacoes_postagem .", inline=False)
     embed.add_field(name="Versão em execução", value="3.0.0", inline=False)
 

--- a/src/model/posts/post_facebook.py
+++ b/src/model/posts/post_facebook.py
@@ -11,9 +11,22 @@ class PostFacebook:
 
         self.lista_de_capitulos = obra.lista_de_capitulos
 
-        self.imagem_obra = dados_unicos_obras[self.titulo_obra]['url_imagem']
+        # Itera sobre a lista de obras (mesmo padrão do PostDiscord) em vez de
+        # indexar como dict, o que causaria TypeError pois dados_unicos_obras é list.
+        obra_encontrada = None
+        for dados_obra in dados_unicos_obras:
+            if dados_obra.get('titulo') == self.titulo_obra:
+                obra_encontrada = dados_obra
+                break
 
-        self.logger_infos.info(f"Construindo Post {self.titulo_obra }...")
+        if obra_encontrada:
+            self.imagem_obra = obra_encontrada['url_imagem']
+        else:
+            self.logger_infos.warning(
+                f"Obra '{self.titulo_obra}' não encontrada em dados_unicos_obras."
+            )
+
+        self.logger_infos.info(f"Construindo Post {self.titulo_obra}...")
 
     
     def retornar_mensagem_post(self):

--- a/tests/test_controller_obras.py
+++ b/tests/test_controller_obras.py
@@ -25,21 +25,24 @@ class TestControllerObras:
 
 
     def test_remover_obras_que_nao_pode_postar(self):
-        # Mock data
+        """
+        Valida a lógica de whitelist: apenas obras presentes na lista
+        de permitidas devem ser retornadas.
+        """
         lista_de_obras_para_postar = [
             Obra("Obra Teste 1", "Teste", "Teste"),
             Obra("Obra Teste 2", "Teste", "Teste"),
             Obra("Obra Teste 3", "Teste", "Teste")
         ]
-        lista_de_obras_nao_permitidas = [
-            {'titulo_obra': 'Obra Teste 2'},
-            {'titulo_obra': 'Obra Teste 3'}
+        # Apenas Obra Teste 1 está na whitelist
+        lista_de_obras_permitidas = [
+            {'titulo_obra': 'Obra Teste 1'},
         ]
 
-        # Call the function
-        obras_filtradas = ControllerObras.remover_obras_que_nao_pode_postar(lista_de_obras_para_postar, lista_de_obras_nao_permitidas)
+        obras_filtradas = ControllerObras.filtrar_obras_permitidas_fb(
+            lista_de_obras_para_postar, lista_de_obras_permitidas
+        )
 
-        # Assert the results
         assert len(obras_filtradas) == 1
         assert obras_filtradas[0].titulo_obra == 'Obra Teste 1'
 

--- a/tests/test_dao_conexao_facebook.py
+++ b/tests/test_dao_conexao_facebook.py
@@ -12,79 +12,77 @@ from src.model.posts.post_facebook import PostFacebook
 
 class TestRegraDeNegocioFacebook:
     """
-    Testes de regra de negócio para postagem no Facebook.
+    Testes de regra de negócio para postagem no Facebook (whitelist).
     Estes testes não fazem chamadas à API — sempre executam.
     """
 
-    def test_obras_nao_permitidas_sao_removidas_da_lista(self):
+    def test_somente_obras_permitidas_sao_retornadas(self):
         """
-        Garante que obras na lista de não permitidas são excluídas
-        da lista de obras a postar no Facebook.
+        Apenas obras cujo título consta na whitelist devem ser retornadas.
         """
         lista_para_postar = [
             Obra("Obra A", "http://img.com/a.png", "http://site.com/a"),
             Obra("Obra B", "http://img.com/b.png", "http://site.com/b"),
             Obra("Obra C", "http://img.com/c.png", "http://site.com/c"),
         ]
-        nao_permitidas = [
-            {"titulo_obra": "Obra B"},
-            {"titulo_obra": "Obra C"},
+        permitidas = [
+            {"titulo_obra": "Obra A"},
         ]
 
-        resultado = ControllerObras.remover_obras_que_nao_pode_postar(
-            lista_para_postar, nao_permitidas
+        resultado = ControllerObras.filtrar_obras_permitidas_fb(
+            lista_para_postar, permitidas
         )
 
         assert len(resultado) == 1
         assert resultado[0].titulo_obra == "Obra A"
 
-    def test_lista_vazia_de_nao_permitidas_retorna_todas_as_obras(self):
+    def test_whitelist_vazia_retorna_lista_vazia(self):
         """
-        Com lista de não permitidas vazia, todas as obras devem ser retornadas.
+        Com a whitelist vazia, nenhuma obra deve ser retornada.
         """
         lista_para_postar = [
             Obra("Obra A", "http://img.com/a.png", "http://site.com/a"),
             Obra("Obra B", "http://img.com/b.png", "http://site.com/b"),
         ]
 
-        resultado = ControllerObras.remover_obras_que_nao_pode_postar(
+        resultado = ControllerObras.filtrar_obras_permitidas_fb(
             lista_para_postar, []
-        )
-
-        assert len(resultado) == 2
-
-    def test_todas_obras_nao_permitidas_retorna_lista_vazia(self):
-        """
-        Se todas as obras estiverem na lista de não permitidas,
-        o resultado deve ser uma lista vazia.
-        """
-        lista_para_postar = [
-            Obra("Obra A", "http://img.com/a.png", "http://site.com/a"),
-            Obra("Obra B", "http://img.com/b.png", "http://site.com/b"),
-        ]
-        nao_permitidas = [
-            {"titulo_obra": "Obra A"},
-            {"titulo_obra": "Obra B"},
-        ]
-
-        resultado = ControllerObras.remover_obras_que_nao_pode_postar(
-            lista_para_postar, nao_permitidas
         )
 
         assert len(resultado) == 0
 
-    def test_obra_nao_listada_como_nao_permitida_permanece(self):
+    def test_todas_obras_permitidas_retorna_lista_completa(self):
         """
-        Obras cujo título não consta na lista de não permitidas devem
-        ser mantidas na lista de postagem.
+        Se todas as obras estiverem na whitelist, todas devem ser retornadas.
+        """
+        lista_para_postar = [
+            Obra("Obra A", "http://img.com/a.png", "http://site.com/a"),
+            Obra("Obra B", "http://img.com/b.png", "http://site.com/b"),
+        ]
+        permitidas = [
+            {"titulo_obra": "Obra A"},
+            {"titulo_obra": "Obra B"},
+        ]
+
+        resultado = ControllerObras.filtrar_obras_permitidas_fb(
+            lista_para_postar, permitidas
+        )
+
+        assert len(resultado) == 2
+
+    def test_obra_nao_listada_na_whitelist_e_removida(self):
+        """
+        Obra ausente da whitelist não deve aparecer no resultado,
+        mesmo que não esteja em nenhuma lista de bloqueio.
         """
         lista_para_postar = [
             Obra("Obra Permitida", "http://img.com/p.png", "http://site.com/p"),
+            Obra("Obra Sem Permissao", "http://img.com/s.png", "http://site.com/s"),
         ]
-        nao_permitidas = [{"titulo_obra": "Outra Obra"}]
+        permitidas = [{"titulo_obra": "Obra Permitida"}]
 
-        resultado = ControllerObras.remover_obras_que_nao_pode_postar(
-            lista_para_postar, nao_permitidas
+        resultado = ControllerObras.filtrar_obras_permitidas_fb(
+            lista_para_postar, permitidas
         )
 
         assert len(resultado) == 1
@@ -121,6 +119,96 @@ class TestFlagEnableFbTest:
                 ConexaoFacebook.postar_anuncio_facebook(post_facebook)
 
         assert mock_post.call_count == 0
+
+
+class TestWhitelistFluxoPostagem:
+    """
+    Testes que validam o fluxo completo: whitelist do Atlas → postagem.
+
+    Simula o trecho do ControllerPostagem que consulta a whitelist e
+    chama ConexaoFacebook, garantindo que apenas obras autorizadas
+    chegam à API do Facebook.
+    """
+
+    def _simular_fluxo_fb(
+        self,
+        lista_obras: list,
+        whitelist: list,
+        mock_fb,
+    ) -> list:
+        """
+        Reproduz o trecho de postagem do FB de execucao_principal,
+        retornando os títulos das obras que foram efetivamente postadas.
+        """
+        obras_postadas = []
+
+        obras_permitidas = ControllerObras.filtrar_obras_permitidas_fb(
+            lista_obras, whitelist
+        )
+
+        for obra in obras_permitidas:
+            post = PostFacebook(obra, [])
+            cap = Capitulo("1", "http://site.com/cap1", "março 7, 2026")
+            post.lista_de_capitulos.append(cap)
+            mock_fb(post)
+            obras_postadas.append(obra.titulo_obra)
+
+        return obras_postadas
+
+    def test_obra_fora_da_whitelist_nao_e_postada(self):
+        """
+        Obra ausente da whitelist do Atlas não deve gerar chamada ao
+        Facebook, mesmo que tenha capítulos novos.
+        """
+        lista_obras = [
+            Obra("Obra Sem Permissao", "http://img.com/s.png", "http://site.com/s"),
+        ]
+        whitelist = []  # Atlas retorna vazio — nenhuma obra autorizada
+
+        mock_fb = MagicMock()
+        postadas = self._simular_fluxo_fb(lista_obras, whitelist, mock_fb)
+
+        assert mock_fb.call_count == 0
+        assert postadas == []
+
+    def test_obra_na_whitelist_e_postada(self):
+        """
+        Obra presente na whitelist do Atlas deve ser postada no Facebook.
+        """
+        lista_obras = [
+            Obra("Obra Permitida", "http://img.com/p.png", "http://site.com/p"),
+        ]
+        whitelist = [{"titulo_obra": "Obra Permitida"}]
+
+        mock_fb = MagicMock()
+        postadas = self._simular_fluxo_fb(lista_obras, whitelist, mock_fb)
+
+        assert mock_fb.call_count == 1
+        assert postadas == ["Obra Permitida"]
+
+    def test_apenas_obras_da_whitelist_sao_postadas(self):
+        """
+        Com múltiplas obras, apenas as presentes na whitelist devem
+        ser postadas; as demais devem ser ignoradas.
+        """
+        lista_obras = [
+            Obra("Obra A", "http://img.com/a.png", "http://site.com/a"),
+            Obra("Obra B", "http://img.com/b.png", "http://site.com/b"),
+            Obra("Obra C", "http://img.com/c.png", "http://site.com/c"),
+        ]
+        # Apenas A e C estão autorizadas
+        whitelist = [
+            {"titulo_obra": "Obra A"},
+            {"titulo_obra": "Obra C"},
+        ]
+
+        mock_fb = MagicMock()
+        postadas = self._simular_fluxo_fb(lista_obras, whitelist, mock_fb)
+
+        assert mock_fb.call_count == 2
+        assert "Obra A" in postadas
+        assert "Obra C" in postadas
+        assert "Obra B" not in postadas
 
 
 class TestConexaoFacebook:

--- a/tests/test_dao_conexao_facebook.py
+++ b/tests/test_dao_conexao_facebook.py
@@ -1,0 +1,204 @@
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from dotenv import load_dotenv
+from src.dao.conexao_facebook import ConexaoFacebook
+from src.dao.atlas_dao import AtlasDAO
+from src.controller.controller_obras import ControllerObras
+from src.model.capitulo import Capitulo
+from src.model.obra import Obra
+from src.model.posts.post_facebook import PostFacebook
+
+
+class TestRegraDeNegocioFacebook:
+    """
+    Testes de regra de negócio para postagem no Facebook.
+    Estes testes não fazem chamadas à API — sempre executam.
+    """
+
+    def test_obras_nao_permitidas_sao_removidas_da_lista(self):
+        """
+        Garante que obras na lista de não permitidas são excluídas
+        da lista de obras a postar no Facebook.
+        """
+        lista_para_postar = [
+            Obra("Obra A", "http://img.com/a.png", "http://site.com/a"),
+            Obra("Obra B", "http://img.com/b.png", "http://site.com/b"),
+            Obra("Obra C", "http://img.com/c.png", "http://site.com/c"),
+        ]
+        nao_permitidas = [
+            {"titulo_obra": "Obra B"},
+            {"titulo_obra": "Obra C"},
+        ]
+
+        resultado = ControllerObras.remover_obras_que_nao_pode_postar(
+            lista_para_postar, nao_permitidas
+        )
+
+        assert len(resultado) == 1
+        assert resultado[0].titulo_obra == "Obra A"
+
+    def test_lista_vazia_de_nao_permitidas_retorna_todas_as_obras(self):
+        """
+        Com lista de não permitidas vazia, todas as obras devem ser retornadas.
+        """
+        lista_para_postar = [
+            Obra("Obra A", "http://img.com/a.png", "http://site.com/a"),
+            Obra("Obra B", "http://img.com/b.png", "http://site.com/b"),
+        ]
+
+        resultado = ControllerObras.remover_obras_que_nao_pode_postar(
+            lista_para_postar, []
+        )
+
+        assert len(resultado) == 2
+
+    def test_todas_obras_nao_permitidas_retorna_lista_vazia(self):
+        """
+        Se todas as obras estiverem na lista de não permitidas,
+        o resultado deve ser uma lista vazia.
+        """
+        lista_para_postar = [
+            Obra("Obra A", "http://img.com/a.png", "http://site.com/a"),
+            Obra("Obra B", "http://img.com/b.png", "http://site.com/b"),
+        ]
+        nao_permitidas = [
+            {"titulo_obra": "Obra A"},
+            {"titulo_obra": "Obra B"},
+        ]
+
+        resultado = ControllerObras.remover_obras_que_nao_pode_postar(
+            lista_para_postar, nao_permitidas
+        )
+
+        assert len(resultado) == 0
+
+    def test_obra_nao_listada_como_nao_permitida_permanece(self):
+        """
+        Obras cujo título não consta na lista de não permitidas devem
+        ser mantidas na lista de postagem.
+        """
+        lista_para_postar = [
+            Obra("Obra Permitida", "http://img.com/p.png", "http://site.com/p"),
+        ]
+        nao_permitidas = [{"titulo_obra": "Outra Obra"}]
+
+        resultado = ControllerObras.remover_obras_que_nao_pode_postar(
+            lista_para_postar, nao_permitidas
+        )
+
+        assert len(resultado) == 1
+        assert resultado[0].titulo_obra == "Obra Permitida"
+
+
+class TestFlagEnableFbTest:
+    """
+    Testes que validam o comportamento da flag ENABLE_FB_TEST.
+
+    Quando true sem credenciais de teste: não posta em lugar nenhum.
+    Quando true com credenciais de teste: posta na página de teste.
+    """
+
+    def test_sem_credenciais_de_teste_nao_faz_chamada_api(
+        self, monkeypatch
+    ):
+        """
+        Quando ENABLE_FB_TEST=true mas as variáveis de ambiente da
+        página de teste estão ausentes, nenhuma chamada à API deve
+        ser feita.
+        """
+        monkeypatch.setenv("ENABLE_FB_TEST", "true")
+        monkeypatch.delenv("API_TOKEN_PAGINA_TESTE", raising=False)
+        monkeypatch.delenv("API_ID_PAGINA_FACEBOOK_TESTE", raising=False)
+
+        obra = Obra("Teste", "http://img.com/a.png", "http://site.com/a")
+        post_facebook = PostFacebook(obra, [])
+        capitulo = Capitulo("1", "http://site.com/cap1", "março 7, 2026")
+        post_facebook.lista_de_capitulos.append(capitulo)
+
+        with patch("src.dao.conexao_facebook.requests.post") as mock_post:
+            with patch("src.dao.conexao_facebook.load_dotenv"):
+                ConexaoFacebook.postar_anuncio_facebook(post_facebook)
+
+        assert mock_post.call_count == 0
+
+
+class TestConexaoFacebook:
+    """
+    Testes para postagem no Facebook.
+
+    Por padrão, os testes estão DESABILITADOS para evitar postagens acidentais.
+    Para habilitar, defina ENABLE_FB_TEST=true no .env e execute:
+        pytest tests/test_dao_conexao_facebook.py
+    """
+
+    def test_postagem_facebook_esta_funcionando(self):
+        """
+        Testa a postagem de dois capítulos no Facebook.
+        Requer ENABLE_FB_TEST=true no .env para executar.
+        """
+        load_dotenv(override=True)
+        if os.getenv("ENABLE_FB_TEST", "false").lower() != "true":
+            pytest.skip("ENABLE_FB_TEST não está true no .env")
+        atlas_dao = AtlasDAO()
+
+        # Cria uma obra de teste
+        obra = Obra(
+            "Teste de Postagem",
+            "https://tsundoku.com.br/wp-content/uploads/2022/02/Gosu_The_Master1.png",
+            "https://tsundoku.com.br/manga/teste-de-postagem/"
+        )
+
+        post_facebook = PostFacebook(obra, atlas_dao.receber_obras())
+
+        # Adiciona capítulos de teste
+        capitulo_um = Capitulo(
+            "9998",
+            "https://tsundoku.com.br/teste-cap-9998/",
+            "março 4, 2026"
+        )
+
+        capitulo_dois = Capitulo(
+            "9999",
+            "https://tsundoku.com.br/teste-cap-9999/",
+            "março 4, 2026"
+        )
+
+        post_facebook.lista_de_capitulos += [capitulo_um, capitulo_dois]
+
+        # Executa a postagem
+        ConexaoFacebook.postar_anuncio_facebook(post_facebook)
+
+        # Se chegou aqui sem exceção, o teste passou
+        assert True
+
+    def test_postagem_facebook_um_capitulo(self):
+        """
+        Testa a postagem de um único capítulo no Facebook.
+        Requer ENABLE_FB_TEST=true no .env para executar.
+        """
+        load_dotenv(override=True)
+        if os.getenv("ENABLE_FB_TEST", "false").lower() != "true":
+            pytest.skip("ENABLE_FB_TEST não está true no .env")
+        atlas_dao = AtlasDAO()
+
+        obra = Obra(
+            "Teste de Postagem",
+            "https://tsundoku.com.br/wp-content/uploads/2022/02/Gosu_The_Master1.png",
+            "https://tsundoku.com.br/manga/teste-de-postagem/"
+        )
+
+        post_facebook = PostFacebook(obra, atlas_dao.receber_obras())
+
+        capitulo = Capitulo(
+            "100",
+            "https://tsundoku.com.br/teste-cap-100/",
+            "março 4, 2026"
+        )
+
+        post_facebook.lista_de_capitulos.append(capitulo)
+
+        # Executa a postagem
+        ConexaoFacebook.postar_anuncio_facebook(post_facebook)
+
+        assert True

--- a/tests/test_dao_web_screper.py
+++ b/tests/test_dao_web_screper.py
@@ -2,14 +2,23 @@ import locale
 import datetime
 import logging
 
+from dotenv import load_dotenv
 from src.dao.web_screper_site import WebScreperSite
+
+load_dotenv()
+
+MESES_PORTUGUES = [
+    'janeiro', 'fevereiro', 'março', 'abril', 'maio', 'junho',
+    'julho', 'agosto', 'setembro', 'outubro', 'novembro', 'dezembro'
+]
+
 
 class TestWebScreper:
     def test_valida_se_esta_recebendo_dados_obras(self):
         web_screper = WebScreperSite()
         dados_obra = web_screper.receber_conteudo(5)
 
-        [print(dado) for dado in dados_obra ]
+        [print(dado) for dado in dados_obra]
 
         assert len(dados_obra[0]) > 0
         assert len(dados_obra[1]) > 0
@@ -17,39 +26,30 @@ class TestWebScreper:
         assert len(dados_obra[3]) > 0
         assert len(dados_obra[4]) > 0
 
-
     def test_valida_se_esta_recebendo_capitulos_obras(self):
         web_screper = WebScreperSite()
         dados_obra = web_screper.recebe_capitulos_diarios()
 
-        [print(obra) for obra in dados_obra ]
+        [print(obra) for obra in dados_obra]
 
         assert len(dados_obra) > 0
 
-
     def test_verifica_se_data_esta_em_portugues(self):
+        """
+        Verifica se as datas retornadas pelo scraper estão no formato
+        em português (ex: 'março 7, 2026').
+        Usa lista fixa de meses para não depender do locale do sistema.
+        """
         web_screper = WebScreperSite()
         datas = web_screper.receber_datas()
 
         logger_infos = logging.getLogger('logger_infos')
         logger_infos.info(datas)
 
-        locale.setlocale(locale.LC_TIME, 'pt_BR.utf8')
-
         for data in datas:
-            try:
-                # Tenta fazer o parse da data
-                dt = datetime.datetime.strptime(data, '%B %d, %Y')
-                logger_infos.info(f"A data {dt} está em um formato válido")
-
-            except ValueError:
-                assert False, f"A data {data} está em um formato inválido"
-            
-            # Verifica se o nome do mês está em português
-            mes_numero = dt.month
-            nome_mes_portugues = datetime.date(1900, mes_numero, 1).strftime('%B').lower()
-
-            assert nome_mes_portugues in [
-                'janeiro', 'fevereiro', 'março', 'abril', 'maio', 'junho',
-                'julho', 'agosto', 'setembro', 'outubro', 'novembro', 'dezembro'
-            ], f"A data {data} não está em português"
+            partes = data.split()
+            assert len(partes) >= 1, f"Formato de data inesperado: {data}"
+            mes = partes[0].lower().rstrip(',')
+            assert mes in MESES_PORTUGUES, (
+                f"Mês '{mes}' não está em português na data '{data}'"
+            )

--- a/tests/test_postagem.py
+++ b/tests/test_postagem.py
@@ -1,8 +1,11 @@
+from dotenv import load_dotenv
 from src.dao.atlas_dao import AtlasDAO
 from src.model.obra import Obra
 from src.model.capitulo import Capitulo
 from src.controller.controller_obras import ControllerObras
 from src.dao.web_screper_site import WebScreperSite
+
+load_dotenv()
 
 class TestPostagem:
     def test_verifica_remocao_obras_nao_registradas(self):


### PR DESCRIPTION
## O que mudou

### 🚀 Facebook — Graph API v25.0
- Reescrita completa de `conexao_facebook.py` usando `requests` direto (removido `facebook-sdk` deprecated)
- Fluxo de postagem em duas etapas: upload da imagem com `published=false` → publicação no feed com `attached_media`
- Suporte a modo de teste via `ENABLE_FB_TEST`: usa credenciais de página separada sem afetar produção

### ♻️ Blacklist → Whitelist de obras
- Lógica invertida: apenas obras explicitamente permitidas são postadas no Facebook
- Novo método `listar_obras_permitidas_fb()` e `inserir_obra_permitida_fb()` no `AtlasDAO`
- Novo método `filtrar_obras_permitidas_fb()` no `ControllerObras`
- Comandos Discord atualizados: `/adicionar_obra_permitida_fb` e `/listar_obras_permitidas_fb`

### 🧪 Testes
- Suite completa para Facebook: regras de negócio, flag `ENABLE_FB_TEST`, fluxo de whitelist e integração real
- Corrigido `test_controller_obras.py` para whitelist
- Corrigido `test_dao_web_screper.py`: removida dependência de locale
- Adicionado `load_dotenv()` em `test_postagem.py` e `test_dao_web_screper.py`
- **39/39 testes passando**

### 📝 Documentação
- Novo `docs/configuracao_facebook.md`: passo a passo completo para criar app Meta, configurar permissões e gerar token via `/me/accounts`
- `.envExample` reescrito com todas as 12 variáveis documentadas e organizadas por seção
- README atualizado com link para o novo guia

### ⚙️ CI/CD
- Novo workflow `release.yml`: gera release notes com `git-cliff` e publica GitHub Release automaticamente no push de tag `v*`
- `test-pytest.yaml` atualizado com todas as variáveis de ambiente necessárias